### PR TITLE
Can cleanup albacore runs and failed reads

### DIFF
--- a/configs/minion.yaml
+++ b/configs/minion.yaml
@@ -4,6 +4,8 @@ KIT: "SQK-RBK004"
 ALBACORE_VERSION: "2.3.3" #available versions : 2.3.0 , 2.3.1 , 2.3.3
 #input base directory of raw fast5 files from MiniKnow
 BASEDIR: "fast5"
+CLEANUP: "True" # cleanup individual albacore runs on sucessfully completion. Values allowed 'True' or 'False'
+DELETE_FAILED: "True" #do not keep fail/*.fastq files in final results. Values allowed 'True' or 'False'
 
 #Variables below should not have to be modified on a run by run basis
 #script for aggregating individual albacore runs

--- a/configs/minion.yaml
+++ b/configs/minion.yaml
@@ -4,8 +4,8 @@ KIT: "SQK-RBK004"
 ALBACORE_VERSION: "2.3.3" #available versions : 2.3.0 , 2.3.1 , 2.3.3
 #input base directory of raw fast5 files from MiniKnow
 BASEDIR: "fast5"
-CLEANUP: "True" # cleanup individual albacore runs on sucessfully completion. Values allowed 'True' or 'False'
-DELETE_FAILED: "True" #do not keep fail/*.fastq files in final results. Values allowed 'True' or 'False'
+CLEANUP: "False" # cleanup individual albacore runs on sucessfully completion. Values allowed 'True' or 'False'
+DELETE_FAILED: "False" #do not keep fail/*.fastq files in final results. Values allowed 'True' or 'False'
 
 #Variables below should not have to be modified on a run by run basis
 #script for aggregating individual albacore runs


### PR DESCRIPTION
added ability for user to automatically cleanup individual albacore_r…esults on completion of the snakemake run. Users can now indicate if they want to keep the combined fail reads as well in results/fail folder.

To address #2 issue